### PR TITLE
Hotfix v5.1.3

### DIFF
--- a/lib/rolify/adapters/base.rb
+++ b/lib/rolify/adapters/base.rb
@@ -27,7 +27,7 @@ module Rolify
       end
 
       def relation_types_for(relation)
-        relation.descendants.map(&:base_class).map(&:to_s).push(relation.to_s).uniq
+        relation.descendants.map(&:base_class).map(&:to_s).push(relation.base_class.to_s).uniq
       end
     end
 

--- a/lib/rolify/adapters/base.rb
+++ b/lib/rolify/adapters/base.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Rolify
   module Adapter
     class Base
@@ -9,15 +11,15 @@ module Rolify
       def role_class
         @role_cname.constantize
       end
-      
+
       def user_class
         @user_cname.constantize
       end
-      
+
       def role_table
         role_class.table_name
       end
-      
+
       def self.create(adapter, role_cname, user_cname)
         load "rolify/adapters/#{Rolify.orm}/#{adapter}.rb"
         load "rolify/adapters/#{Rolify.orm}/scopes.rb"
@@ -25,41 +27,40 @@ module Rolify
       end
 
       def relation_types_for(relation)
-        relation.descendants.map(&:to_s).push(relation.to_s)
+        relation.descendants.map(&:base_class).map(&:to_s).push(relation.to_s)
       end
     end
 
     class RoleAdapterBase < Adapter::Base
-      def where(relation, args)
-        raise NotImplementedError.new("You must implement where")
+      def where(_relation, _args)
+        raise NotImplementedError, 'You must implement where'
       end
 
-      def find_or_create_by(role_name, resource_type = nil, resource_id = nil)
-        raise NotImplementedError.new("You must implement find_or_create_by")
+      def find_or_create_by(_role_name, _resource_type = nil, _resource_id = nil)
+        raise NotImplementedError, 'You must implement find_or_create_by'
       end
 
-      def add(relation, role_name, resource = nil)
-        raise NotImplementedError.new("You must implement add")
+      def add(_relation, _role_name, _resource = nil)
+        raise NotImplementedError, 'You must implement add'
       end
 
-      def remove(relation, role_name, resource = nil)
-        raise NotImplementedError.new("You must implement delete")
+      def remove(_relation, _role_name, _resource = nil)
+        raise NotImplementedError, 'You must implement delete'
       end
 
-      def exists?(relation, column)
-        raise NotImplementedError.new("You must implement exists?")
+      def exists?(_relation, _column)
+        raise NotImplementedError, 'You must implement exists?'
       end
     end
 
     class ResourceAdapterBase < Adapter::Base
-      def resources_find(roles_table, relation, role_name)
-        raise NotImplementedError.new("You must implement resources_find")
+      def resources_find(_roles_table, _relation, _role_name)
+        raise NotImplementedError, 'You must implement resources_find'
       end
 
-      def in(resources, roles)
-        raise NotImplementedError.new("You must implement in")
+      def in(_resources, _roles)
+        raise NotImplementedError, 'You must implement in'
       end
-
     end
   end
 end

--- a/lib/rolify/adapters/base.rb
+++ b/lib/rolify/adapters/base.rb
@@ -27,7 +27,7 @@ module Rolify
       end
 
       def relation_types_for(relation)
-        relation.descendants.map(&:base_class).map(&:to_s).push(relation.to_s)
+        relation.descendants.map(&:base_class).map(&:to_s).push(relation.to_s).uniq
       end
     end
 


### PR DESCRIPTION
## Description
STI does not work with rolify out-of-the-box, as it tries to assign roles to the subclass instead of the base class (Chains::Standard and Chain, respectively).  This fix affects the `relation_types_for` method - we are ensuring that only the base class is used to build the relation for rolify queries.

## Notes
This is necessary for OneCloudInc/oc-server#661