### PR TITLE
STI fixes for adding and removing roles

### DIFF
--- a/lib/rolify/adapters/active_record/role_adapter.rb
+++ b/lib/rolify/adapters/active_record/role_adapter.rb
@@ -51,7 +51,7 @@ module Rolify
 
       def remove(relation, role_name, resource = nil)
         cond = { :name => role_name }
-        cond[:resource_type] = (resource.is_a?(Class) ? resource.to_s : resource.class.name) if resource
+        cond[:resource_type] = (resource.is_a?(Class) ? resource.to_s : resource.class.base_class.name) if resource
         cond[:resource_id] = resource.id if resource && !resource.is_a?(Class)
         roles = relation.roles.where(cond)
         if roles

--- a/lib/rolify/role.rb
+++ b/lib/rolify/role.rb
@@ -11,7 +11,7 @@ module Rolify
 
     def add_role(role_name, resource = nil)
       role = self.class.adapter.find_or_create_by(role_name.to_s,
-                                                  (resource.is_a?(Class) ? resource.to_s : resource.class.name if resource),
+                                                  (resource.is_a?(Class) ? resource.to_s : resource.class.base_class.name if resource),
                                                   (resource.id if resource && !resource.is_a?(Class)))
 
       if !roles.include?(role)


### PR DESCRIPTION
## Description
Rolify's built-in `add_role` and `remove_role` methods did not account for STI.  I updated the relevant methods to use `base_class` instead of `class` in order to get the resource type.